### PR TITLE
Removed loop keyword argument in async_timeout

### DIFF
--- a/custom_components/nextbike/sensor.py
+++ b/custom_components/nextbike/sensor.py
@@ -114,7 +114,7 @@ async def async_nextbike_request(hass, uri, schema):
     try:
         session = async_get_clientsession(hass)
 
-        with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
+        with async_timeout.timeout(REQUEST_TIMEOUT):
             req = await session.get(DEFAULT_ENDPOINT.format(uri=uri))
 
         json_response = await req.json()


### PR DESCRIPTION
I just removed the loop from async_timeout as it is deprecated and will fail in future versions of Home Assistant

```
Logger: homeassistant.helpers.frame
Source: helpers/frame.py:103
First occurred: 08:52:56 (1 occurrences)
Last logged: 08:52:56

Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue to the custom component author for nextbike using this method at custom_components/nextbike/sensor.py, line 117: with async_timeout.timeout(REQUEST_TIMEOUT, loop=hass.loop):
```


// Offtopic
Oh je, mein erster Pull request 👯‍♂️ 

Ich hoffe ich habe es halbwegs korrekt gemacht. Hab's bei mir lokal editiert und nach einem Restart ist die Warnung verschwunden, so funktionieren Tests in 2022 :D